### PR TITLE
add jdk 7/9/10/11 in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,10 @@ language: java
 script:
   - mvn test
 jdk:
+  - openjdk7
   - oraclejdk8
   - openjdk8
+  - oraclejdk9
+  - openjdk10
+  - oraclejdk11
+  - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -36,24 +36,6 @@
 
 	<build>
 		<plugins>
-      <!-- formatter and sort pom -->
-      <plugin>
-	      <groupId>net.revelc.code.formatter</groupId>
-	      <artifactId>formatter-maven-plugin</artifactId>
-	      <version>2.8.1</version>
-	      <configuration>
-		      <configFile>${project.basedir}/eclipse-java-google-style.xml</configFile>
-		      <lineEnding>LF</lineEnding>
-          <encoding>utf-8</encoding>
-	      </configuration>
-	      <executions>
-		      <execution>
-			      <goals>
-				      <goal>format</goal>
-			      </goals>
-		      </execution>
-	      </executions>
-      </plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>3.1.0</version>
@@ -64,22 +46,6 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
-				<executions>
-					<execution>
-						<id>attach-javadoc</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -135,6 +101,51 @@
 		</dependency>
 	</dependencies>
 	<profiles>
+		<profile>
+			<id>auto-activation-for-jdk8+</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<build>
+				<!-- blow plugins require jdk8+ -->
+				<plugins>
+					<!-- formatter and sort pom -->
+					<plugin>
+						<groupId>net.revelc.code.formatter</groupId>
+						<artifactId>formatter-maven-plugin</artifactId>
+						<version>2.9.0</version>
+						<configuration>
+							<configFile>${project.basedir}/eclipse-java-google-style.xml</configFile>
+							<lineEnding>LF</lineEnding>
+							<encoding>utf-8</encoding>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>format</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.10.4</version>
+						<executions>
+							<execution>
+								<id>attach-javadoc</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+								<configuration>
+									<additionalparam>-Xdoclint:none</additionalparam>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>release</id>
 			<activation>

--- a/src/test/java/com/googlecode/aviator/test/function/FunctionTest.java
+++ b/src/test/java/com/googlecode/aviator/test/function/FunctionTest.java
@@ -1018,7 +1018,16 @@ public class FunctionTest {
       assertEquals(1, AviatorEvaluator.execute("seq.get(seq.list(1,1,2,3),4)"));
       fail();
     } catch (ExpressionRuntimeException e) {
-      assertEquals("Index: 4, Size: 4", e.getCause().getMessage());
+      // Jdk changed the message of IndexOutOfBoundsException:
+      //   - for jdk 8-, cause exception is
+      //     java.lang.IndexOutOfBoundsException: Index: 4, Size: 4
+      //   - for jdk 9/10, exception is
+      //     java.lang.IndexOutOfBoundsException: Index 4 out-of-bounds for length 4
+      //   - for jdk 11, exception is
+      //     java.lang.IndexOutOfBoundsException: Index 4 out of bounds for length 4
+      assertTrue(e.getCause().getMessage().equals("Index: 4, Size: 4")
+          || e.getCause().getMessage().equals("Index 4 out-of-bounds for length 4")
+          || e.getCause().getMessage().equals("Index 4 out of bounds for length 4"));
     }
   }
 


### PR DESCRIPTION
- add jdk 7 since aviator supports jdk 7+
- add jdk 9+ since jdk 9+ supports the big new feature `modularity`
- add jdk 11 since jdk 11 is current LTS version
